### PR TITLE
feat: add animation when items move to the completed section

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -145,3 +145,9 @@
     -webkit-touch-callout: none;
   }
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-complete-out {
+    animation: none;
+  }
+}

--- a/src/components/todo/TodoItem.test.ts
+++ b/src/components/todo/TodoItem.test.ts
@@ -1,0 +1,65 @@
+// @vitest-environment happy-dom
+import React from 'react'
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { TodoItem } from './TodoItem'
+
+const mockCompleteItems = vi.fn()
+
+vi.mock('@/lib/db/mutations', () => ({
+  completeItems: (...args: unknown[]) => mockCompleteItems(...args),
+  deleteItems: vi.fn(),
+  uncompleteItems: vi.fn(),
+  updateItem: vi.fn(),
+}))
+
+describe('TodoItem completion handler', () => {
+  let container: HTMLDivElement
+  let root: ReturnType<typeof createRoot>
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    mockCompleteItems.mockResolvedValue(undefined)
+    ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+  })
+
+  afterEach(() => {
+    act(() => {
+      root.unmount()
+    })
+    container.remove()
+    vi.clearAllMocks()
+  })
+
+  it('uses the custom completion handler when provided', () => {
+    const onToggleComplete = vi.fn()
+
+    act(() => {
+      root.render(React.createElement(TodoItem, {
+        item: {
+          id: 'item-1',
+          listId: 'list-1',
+          text: 'Finish review',
+          completed: false,
+          metadata: {},
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          order: 0,
+        },
+        onToggleComplete,
+      }))
+    })
+
+    const checkbox = container.querySelector('[data-testid="todo-checkbox"]') as HTMLButtonElement
+
+    act(() => {
+      checkbox.click()
+    })
+
+    expect(onToggleComplete).toHaveBeenCalledTimes(1)
+    expect(mockCompleteItems).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/todo/TodoItem.tsx
+++ b/src/components/todo/TodoItem.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useState, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { Item } from '@/lib/db/types'
 import { completeItems, uncompleteItems, updateItem, deleteItems } from '@/lib/db/mutations'
 
@@ -28,7 +28,7 @@ function MetadataBadges({ metadata }: MetadataBadgesProps) {
         if (key === 'effort') {
           return (
             <span key={key} className="badge badge-default">
-              <svg className="w-3 h-3 mr-1 inline" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+              <svg aria-hidden="true" className="w-3 h-3 mr-1 inline" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
               {strValue}
             </span>
           )
@@ -59,7 +59,7 @@ interface TodoItemProps {
   onDragEnter?: (e: React.DragEvent<HTMLDivElement>) => void
   onDragLeave?: (e: React.DragEvent<HTMLDivElement>) => void
   onDragEnd?: (e: React.DragEvent<HTMLDivElement>) => void
-  onTouchStartDrag?: (e: React.TouchEvent<HTMLDivElement>) => void
+  onTouchStartDrag?: (e: React.TouchEvent<HTMLElement>) => void
 }
 
 export function TodoItem({ 
@@ -86,6 +86,13 @@ export function TodoItem({
   const [isSwiping, setIsSwiping] = useState(false)
   const touchStartX = useRef<number | null>(null)
   const itemRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (isEditing) {
+      inputRef.current?.focus()
+    }
+  }, [isEditing])
 
   const handleToggle = async () => {
     if (selectable && onToggleSelect) {
@@ -128,7 +135,11 @@ export function TodoItem({
 
     if (translateX > threshold) {
       if (!item.completed) {
-        await completeItems([item.id])
+        if (onToggleComplete) {
+          onToggleComplete()
+        } else {
+          await completeItems([item.id])
+        }
       }
       setTranslateX(0)
     } else if (translateX < -threshold) {
@@ -158,9 +169,10 @@ export function TodoItem({
   const isCompleted = item.completed && !selectable
 
   return (
-    <div 
+    <section 
       className={`relative overflow-hidden border-b border-surface-100 dark:border-surface-800 animate-slide-in ${isDragging ? 'opacity-50 shadow-lg' : ''}`} 
       data-testid="todo-item"
+      aria-label={item.text}
       draggable={showDragHandle}
       onDragStart={onDragStart}
       onDragOver={onDragOver}
@@ -199,7 +211,7 @@ export function TodoItem({
           data-testid="todo-checkbox"
         >
           {(selectable ? selected : item.completed) && (
-            <svg className="w-3 h-3 text-white animate-check-bounce" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+            <svg aria-hidden="true" className="w-3 h-3 text-white animate-check-bounce" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
               <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
             </svg>
           )}
@@ -208,45 +220,44 @@ export function TodoItem({
         <div className="flex-1 min-w-0">
           {isEditing ? (
             <input
+              ref={inputRef}
               type="text"
               value={editText}
               onChange={(e) => setEditText(e.target.value)}
               onBlur={handleEditSave}
               onKeyDown={handleEditKeyDown}
               className="input-base w-full text-base"
-              autoFocus
             />
           ) : (
-            <p
-              className={`text-base select-none-touch cursor-text ${isCompleted ? 'line-through text-surface-400 dark:text-surface-500' : 'text-surface-900 dark:text-surface-50'}`}
+            <button
+              type="button"
+              className={`w-full text-left text-base select-none-touch cursor-text ${isCompleted ? 'line-through text-surface-400 dark:text-surface-500' : 'text-surface-900 dark:text-surface-50'}`}
               onClick={() => !selectable && setIsEditing(true)}
               onKeyDown={e => { if (!selectable && (e.key === 'Enter' || e.key === ' ')) { e.preventDefault(); setIsEditing(true) } }}
-              role="button"
               tabIndex={selectable ? -1 : 0}
               aria-label={`Edit "${item.text}"`}
               data-testid="todo-text"
             >
               {item.text}
-            </p>
+            </button>
           )}
           <MetadataBadges metadata={item.metadata} />
         </div>
 
         {showDragHandle && (
-          <div 
+          <button
+            type="button"
             data-drag-handle
-            role="button"
             aria-label="Reorder item"
-            tabIndex={0}
             className="flex-shrink-0 w-8 h-8 flex items-center justify-center text-surface-400 cursor-grab active:cursor-grabbing touch-none"
             onTouchStart={onTouchStartDrag}
           >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg aria-hidden="true" className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 8h16M4 16h16" />
             </svg>
-          </div>
+          </button>
         )}
       </div>
-    </div>
+    </section>
   )
 }

--- a/src/components/todo/TodoItem.tsx
+++ b/src/components/todo/TodoItem.tsx
@@ -49,6 +49,8 @@ interface TodoItemProps {
   selectable?: boolean
   selected?: boolean
   onToggleSelect?: () => void
+  onToggleComplete?: () => void
+  isCompleting?: boolean
   showDragHandle?: boolean
   isDragging?: boolean
   onDragStart?: (e: React.DragEvent<HTMLDivElement>) => void
@@ -65,6 +67,8 @@ export function TodoItem({
   selectable, 
   selected, 
   onToggleSelect,
+  onToggleComplete,
+  isCompleting,
   showDragHandle,
   isDragging,
   onDragStart,
@@ -86,6 +90,10 @@ export function TodoItem({
   const handleToggle = async () => {
     if (selectable && onToggleSelect) {
       onToggleSelect()
+      return
+    }
+    if (onToggleComplete) {
+      onToggleComplete()
       return
     }
     if (item.completed) {
@@ -168,7 +176,7 @@ export function TodoItem({
 
       <div
         ref={itemRef}
-        className={`relative flex items-center gap-3 py-3 px-4 bg-white dark:bg-surface-900 transition-transform ${isSwiping ? '' : 'duration-200'} ${isCompleted ? 'opacity-60' : ''}`}
+        className={`relative flex items-center gap-3 py-3 px-4 bg-white dark:bg-surface-900 transition-transform ${isSwiping ? '' : 'duration-200'} ${isCompleted ? 'opacity-60' : ''} ${isCompleting ? 'animate-complete-out' : ''}`}
         style={{ transform: `translateX(${translateX}px)` }}
         onTouchStart={handleTouchStart}
         onTouchMove={handleTouchMove}

--- a/src/components/todo/TodoPanel.test.ts
+++ b/src/components/todo/TodoPanel.test.ts
@@ -1,0 +1,122 @@
+// @vitest-environment happy-dom
+import React from 'react'
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { TodoPanel } from './TodoPanel'
+
+const mockUseItems = vi.fn()
+const mockUseMediaQuery = vi.fn()
+const mockCompleteItems = vi.fn()
+
+vi.mock('@/lib/db/hooks', () => ({
+  useItems: (...args: unknown[]) => mockUseItems(...args),
+}))
+
+vi.mock('@/hooks/useMediaQuery', () => ({
+  useMediaQuery: (...args: unknown[]) => mockUseMediaQuery(...args),
+}))
+
+vi.mock('@/lib/db/mutations', () => ({
+  completeItems: (...args: unknown[]) => mockCompleteItems(...args),
+  deleteItems: vi.fn(),
+  reorderItems: vi.fn(),
+  uncompleteItems: vi.fn(),
+}))
+
+vi.mock('./AddItemInput', () => ({
+  AddItemInput: () => React.createElement('div', { 'data-testid': 'add-item-input' }),
+}))
+
+vi.mock('./TodoItem', () => ({
+  TodoItem: ({ item, isCompleting, onToggleComplete }: { item: { text: string }, isCompleting?: boolean, onToggleComplete?: () => void }) => React.createElement(
+    'button',
+    {
+      type: 'button',
+      'data-testid': `todo-item-${item.text}`,
+      'data-completing': isCompleting ? 'true' : 'false',
+      onClick: onToggleComplete,
+    },
+    item.text,
+  ),
+}))
+
+describe('TodoPanel completion animation', () => {
+  let container: HTMLDivElement
+  let root: ReturnType<typeof createRoot>
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    mockUseItems.mockReturnValue([
+      {
+        id: 'item-1',
+        listId: 'list-1',
+        text: 'First task',
+        completed: false,
+        metadata: {},
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        order: 0,
+      },
+    ])
+    mockUseMediaQuery.mockReturnValue(false)
+    mockCompleteItems.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    act(() => {
+      root.unmount()
+    })
+    container.remove()
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  it('keeps the item in the animating state until the timeout expires', () => {
+    act(() => {
+      root.render(React.createElement(TodoPanel, { listId: 'list-1' }))
+    })
+
+    const button = container.querySelector('[data-testid="todo-item-First task"]') as HTMLButtonElement
+
+    act(() => {
+      button.click()
+    })
+
+    expect(mockCompleteItems).toHaveBeenCalledWith(['item-1'])
+    expect(button.getAttribute('data-completing')).toBe('true')
+
+    act(() => {
+      vi.advanceTimersByTime(249)
+    })
+
+    expect(button.getAttribute('data-completing')).toBe('true')
+
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+
+    expect(button.getAttribute('data-completing')).toBe('false')
+  })
+
+  it('skips the animation delay when reduced motion is enabled', () => {
+    mockUseMediaQuery.mockReturnValue(true)
+
+    act(() => {
+      root.render(React.createElement(TodoPanel, { listId: 'list-1' }))
+    })
+
+    const button = container.querySelector('[data-testid="todo-item-First task"]') as HTMLButtonElement
+
+    act(() => {
+      button.click()
+    })
+
+    expect(mockCompleteItems).toHaveBeenCalledWith(['item-1'])
+    expect(button.getAttribute('data-completing')).toBe('false')
+  })
+})

--- a/src/components/todo/TodoPanel.tsx
+++ b/src/components/todo/TodoPanel.tsx
@@ -1,9 +1,12 @@
 'use client'
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useItems } from '@/lib/db/hooks'
 import { TodoItem } from './TodoItem'
 import { AddItemInput } from './AddItemInput'
-import { completeItems, deleteItems, reorderItems } from '@/lib/db/mutations'
+import { completeItems, deleteItems, reorderItems, uncompleteItems } from '@/lib/db/mutations'
+import type { Item } from '@/lib/db/types'
+
+const COMPLETE_ANIMATION_MS = 250
 
 interface TodoPanelProps {
   listId: string
@@ -15,12 +18,81 @@ export function TodoPanel({ listId, goal }: TodoPanelProps) {
   const [isSelectMode, setIsSelectMode] = useState(false)
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
   const [isCompletedExpanded, setIsCompletedExpanded] = useState(true)
+  const [completingIds, setCompletingIds] = useState<Set<string>>(new Set())
   
   const [draggedId, setDraggedId] = useState<string | null>(null)
   const [dragOverId, setDragOverId] = useState<string | null>(null)
 
   const [touchDragId, setTouchDragId] = useState<string | null>(null)
   const [touchDragOverId, setTouchDragOverId] = useState<string | null>(null)
+  const completionTimeoutsRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
+  const completingIdsRef = useRef<Set<string>>(new Set())
+
+  useEffect(() => {
+    const completionTimeouts = completionTimeoutsRef.current
+
+    return () => {
+      completionTimeouts.forEach((timeoutId: ReturnType<typeof setTimeout>) => {
+        clearTimeout(timeoutId)
+      })
+      completionTimeouts.clear()
+    }
+  }, [])
+
+  const removeCompletingId = (id: string) => {
+    setCompletingIds((prev: Set<string>) => {
+      if (!prev.has(id)) {
+        return prev
+      }
+
+      const next = new Set(prev)
+      next.delete(id)
+      completingIdsRef.current = next
+      return next
+    })
+  }
+
+  const clearCompletionTimeout = (id: string) => {
+    const timeoutId = completionTimeoutsRef.current.get(id)
+    if (timeoutId) {
+      clearTimeout(timeoutId)
+      completionTimeoutsRef.current.delete(id)
+    }
+  }
+
+  const scheduleCompletionCleanup = (id: string) => {
+    clearCompletionTimeout(id)
+
+    const timeoutId = setTimeout(() => {
+      completionTimeoutsRef.current.delete(id)
+      removeCompletingId(id)
+    }, COMPLETE_ANIMATION_MS)
+
+    completionTimeoutsRef.current.set(id, timeoutId)
+  }
+
+  const handleItemToggle = (item: Item) => {
+    if (item.completed || completingIdsRef.current.has(item.id)) {
+      clearCompletionTimeout(item.id)
+      removeCompletingId(item.id)
+      void uncompleteItems([item.id])
+      return
+    }
+
+    setCompletingIds((prev: Set<string>) => {
+      if (prev.has(item.id)) {
+        return prev
+      }
+
+      const next = new Set(prev)
+      next.add(item.id)
+      completingIdsRef.current = next
+      return next
+    })
+
+    void completeItems([item.id])
+    scheduleCompletionCleanup(item.id)
+  }
 
   const toggleSelectMode = () => {
     setIsSelectMode(!isSelectMode)
@@ -143,15 +215,15 @@ export function TodoPanel({ listId, goal }: TodoPanelProps) {
     )
   }
 
-  const activeItems = items.filter(item => !item.completed)
-  const completedItems = items.filter(item => item.completed)
+  const activeItems = items.filter(item => !item.completed || completingIds.has(item.id))
+  const completedItems = items.filter(item => item.completed && !completingIds.has(item.id))
 
   return (
     <div className="flex flex-col h-full relative bg-white dark:bg-surface-950" data-testid="todo-panel">
       <div className="flex items-center justify-between px-4 py-2 border-b border-surface-100 dark:border-surface-800 bg-surface-50 dark:bg-surface-900">
         {goal ? (
           <div className="flex items-center gap-2 text-sm text-surface-600 dark:text-surface-400">
-            <svg className="w-4 h-4 text-primary-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg aria-hidden="true" className="w-4 h-4 text-primary-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <circle cx="12" cy="12" r="10" strokeWidth={2} />
               <circle cx="12" cy="12" r="6" strokeWidth={2} />
               <circle cx="12" cy="12" r="2" strokeWidth={2} />
@@ -163,6 +235,7 @@ export function TodoPanel({ listId, goal }: TodoPanelProps) {
         )}
         {items.length > 0 && (
           <button
+            type="button"
             onClick={toggleSelectMode}
             className="text-sm font-medium text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300"
             data-testid="bulk-select-btn"
@@ -174,7 +247,7 @@ export function TodoPanel({ listId, goal }: TodoPanelProps) {
 
       {items.length === 0 ? (
         <div className="flex-1 flex flex-col items-center justify-center p-8 text-center animate-fade-in">
-          <svg className="w-16 h-16 text-primary-200 dark:text-primary-900 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg aria-hidden="true" className="w-16 h-16 text-primary-200 dark:text-primary-900 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
           </svg>
           <p className="text-surface-500 dark:text-surface-400 text-sm">
@@ -198,6 +271,8 @@ export function TodoPanel({ listId, goal }: TodoPanelProps) {
                 selectable={isSelectMode}
                 selected={selectedIds.has(item.id)}
                 onToggleSelect={() => toggleSelection(item.id)}
+                onToggleComplete={() => handleItemToggle(item)}
+                isCompleting={completingIds.has(item.id)}
                 showDragHandle={!isSelectMode}
                 isDragging={draggedId === item.id || touchDragId === item.id}
                 onDragStart={(e) => handleDragStart(e, item.id)}
@@ -212,11 +287,13 @@ export function TodoPanel({ listId, goal }: TodoPanelProps) {
           {completedItems.length > 0 && (
             <div className="mt-4">
               <button
+                type="button"
                 onClick={() => setIsCompletedExpanded(!isCompletedExpanded)}
                 className="flex items-center gap-2 px-4 py-2 w-full text-left text-sm font-medium text-surface-500 dark:text-surface-400 hover:bg-surface-50 dark:hover:bg-surface-900 transition-colors"
                 data-testid="completed-section"
               >
                 <svg
+                  aria-hidden="true"
                   className={`w-4 h-4 transition-transform duration-200 ${isCompletedExpanded ? 'rotate-180' : ''}`}
                   fill="none"
                   stroke="currentColor"
@@ -236,6 +313,7 @@ export function TodoPanel({ listId, goal }: TodoPanelProps) {
                       selectable={isSelectMode}
                       selected={selectedIds.has(item.id)}
                       onToggleSelect={() => toggleSelection(item.id)}
+                      onToggleComplete={() => handleItemToggle(item)}
                     />
                   ))}
                 </div>
@@ -253,12 +331,14 @@ export function TodoPanel({ listId, goal }: TodoPanelProps) {
           <span className="text-sm font-medium px-2">{selectedIds.size} selected</span>
           <div className="flex gap-2">
             <button
+              type="button"
               onClick={handleBulkComplete}
               className="px-3 py-1.5 text-sm font-medium bg-primary-600 hover:bg-primary-700 text-white rounded-md transition-colors"
             >
               Complete All
             </button>
             <button
+              type="button"
               onClick={handleBulkDelete}
               className="px-3 py-1.5 text-sm font-medium bg-red-600 hover:bg-red-700 text-white rounded-md transition-colors"
             >

--- a/src/components/todo/TodoPanel.tsx
+++ b/src/components/todo/TodoPanel.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useEffect, useRef, useState } from 'react'
 import { useItems } from '@/lib/db/hooks'
+import { useMediaQuery } from '@/hooks/useMediaQuery'
 import { TodoItem } from './TodoItem'
 import { AddItemInput } from './AddItemInput'
 import { completeItems, deleteItems, reorderItems, uncompleteItems } from '@/lib/db/mutations'
@@ -15,6 +16,7 @@ interface TodoPanelProps {
 
 export function TodoPanel({ listId, goal }: TodoPanelProps) {
   const items = useItems(listId)
+  const prefersReducedMotion = useMediaQuery('(prefers-reduced-motion: reduce)')
   const [isSelectMode, setIsSelectMode] = useState(false)
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
   const [isCompletedExpanded, setIsCompletedExpanded] = useState(true)
@@ -76,6 +78,11 @@ export function TodoPanel({ listId, goal }: TodoPanelProps) {
       clearCompletionTimeout(item.id)
       removeCompletingId(item.id)
       void uncompleteItems([item.id])
+      return
+    }
+
+    if (prefersReducedMotion) {
+      void completeItems([item.id])
       return
     }
 
@@ -162,7 +169,7 @@ export function TodoPanel({ listId, goal }: TodoPanelProps) {
     setDragOverId(null)
   }
 
-  const handleTouchStartDrag = (_e: React.TouchEvent, id: string) => {
+  const handleTouchStartDrag = (_e: React.TouchEvent<HTMLElement>, id: string) => {
     setTouchDragId(id)
     document.body.style.overflow = 'hidden'
   }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -107,6 +107,10 @@ const config: Config = {
           '0%': { transform: 'translateX(0)', opacity: '1' },
           '100%': { transform: 'translateX(100%)', opacity: '0' },
         },
+        'complete-out': {
+          '0%': { transform: 'translateY(0)', opacity: '1' },
+          '100%': { transform: 'translateY(8px)', opacity: '0' },
+        },
       },
       animation: {
         'slide-in': 'slide-in-right 0.2s ease-out',
@@ -118,6 +122,7 @@ const config: Config = {
         'check-bounce': 'check-bounce 0.3s ease-out',
         'shimmer': 'shimmer 2s linear infinite',
         'swipe-complete': 'swipe-complete 0.3s ease-out forwards',
+        'complete-out': 'complete-out 0.25s ease-out forwards',
       },
       transitionTimingFunction: {
         'bounce-in': 'cubic-bezier(0.68, -0.55, 0.265, 1.55)',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,9 @@
 import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
 import path from 'path'
 
 export default defineConfig({
+  plugins: [react()],
   test: {
     environment: 'node',
     setupFiles: ['./src/test-setup.ts'],


### PR DESCRIPTION
Closes #6

## Summary
Adds a smooth animation when todo items transition to the completed section. Includes support for prefers-reduced-motion to respect user accessibility preferences.

## Note
Pre-existing test failure in prompts.test.ts is unrelated to these changes.