### PR TITLE
feat: add reorderItems tool so AI can sort list items

### DIFF
--- a/src/lib/llm/executor.test.ts
+++ b/src/lib/llm/executor.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { db } from '@/lib/db'
 import { createList, addItems } from '@/lib/db/mutations'
+import type { Item } from '@/lib/db/types'
 import { executeToolCall } from './executor'
 
 let listId: string
@@ -76,6 +77,62 @@ describe('executeToolCall', () => {
       expect(result.success).toBe(true)
       const items = await db.items.where('listId').equals(listId).toArray()
       expect(items[0].completed).toBe(true)
+    })
+  })
+
+  describe('reorderItems', () => {
+    it('reorders existing items in the requested order', async () => {
+      const items = await addItems(listId, [
+        { text: 'First' },
+        { text: 'Second' },
+        { text: 'Third' },
+      ])
+
+      const result = await executeToolCall('reorderItems', {
+        itemIds: [items[2].id, items[0].id, items[1].id],
+      }, listId)
+
+      expect(result).toEqual({ success: true, notFound: [] })
+
+      const reordered = await db.items.where('listId').equals(listId).sortBy('order')
+      expect(reordered.map((item: Item) => item.id)).toEqual([items[2].id, items[0].id, items[1].id])
+    })
+
+    it('reorders owned items and reports missing IDs', async () => {
+      const items = await addItems(listId, [
+        { text: 'First' },
+        { text: 'Second' },
+        { text: 'Third' },
+      ])
+      const otherList = await createList('Other')
+      const otherItems = await addItems(otherList.id, [{ text: 'Other item' }])
+
+      const result = await executeToolCall('reorderItems', {
+        itemIds: [items[2].id, otherItems[0].id, items[1].id, 'fake-id-123', items[0].id],
+      }, listId)
+
+      expect(result).toEqual({ success: true, notFound: [otherItems[0].id, 'fake-id-123'] })
+
+      const reordered = await db.items.where('listId').equals(listId).sortBy('order')
+      expect(reordered.map((item: Item) => item.id)).toEqual([items[2].id, items[1].id, items[0].id])
+    })
+
+    it('returns all missing IDs without changing local order', async () => {
+      const items = await addItems(listId, [
+        { text: 'First' },
+        { text: 'Second' },
+      ])
+      const otherList = await createList('Other')
+      const otherItems = await addItems(otherList.id, [{ text: 'Other item' }])
+
+      const result = await executeToolCall('reorderItems', {
+        itemIds: [otherItems[0].id, 'fake-id-123'],
+      }, listId)
+
+      expect(result).toEqual({ success: true, notFound: [otherItems[0].id, 'fake-id-123'] })
+
+      const unchanged = await db.items.where('listId').equals(listId).sortBy('order')
+      expect(unchanged.map((item: Item) => item.id)).toEqual([items[0].id, items[1].id])
     })
   })
 

--- a/src/lib/llm/executor.test.ts
+++ b/src/lib/llm/executor.test.ts
@@ -134,6 +134,23 @@ describe('executeToolCall', () => {
       const unchanged = await db.items.where('listId').equals(listId).sortBy('order')
       expect(unchanged.map((item: Item) => item.id)).toEqual([items[0].id, items[1].id])
     })
+
+    it('rejects duplicate IDs without changing order', async () => {
+      const items = await addItems(listId, [
+        { text: 'First' },
+        { text: 'Second' },
+      ])
+
+      const result = await executeToolCall('reorderItems', {
+        itemIds: [items[1].id, items[1].id],
+      }, listId)
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('itemIds must not contain duplicates')
+
+      const unchanged = await db.items.where('listId').equals(listId).sortBy('order')
+      expect(unchanged.map((item: Item) => item.id)).toEqual([items[0].id, items[1].id])
+    })
   })
 
   describe('validation', () => {

--- a/src/lib/llm/executor.ts
+++ b/src/lib/llm/executor.ts
@@ -6,7 +6,9 @@ import {
   uncompleteItems as uncompleteItemsMutation,
   updateItem as updateItemMutation,
   deleteItems as deleteItemsMutation,
+  reorderItems as reorderItemsMutation,
 } from '@/lib/db/mutations'
+import type { Item } from '@/lib/db/types'
 import { todoTools } from './tools'
 
 export interface ToolResult {
@@ -35,7 +37,7 @@ function getErrorMessage(err: unknown): string {
 
 async function splitExistingAndMissingIds(itemIds: string[], listId: string): Promise<{ existingIds: string[]; missingIds: string[] }> {
   const existing = await db.items.where('id').anyOf(itemIds).toArray()
-  const existingIdSet = new Set(existing.filter(item => item.listId === listId).map(item => item.id))
+  const existingIdSet = new Set(existing.filter((item: Item) => item.listId === listId).map((item: Item) => item.id))
   const existingIds = itemIds.filter(id => existingIdSet.has(id))
   const missingIds = itemIds.filter(id => !existingIdSet.has(id))
   return { existingIds, missingIds }
@@ -115,6 +117,15 @@ export async function executeToolCall(
           await deleteItemsMutation(existingIds)
         }
         return { success: true, itemsDeleted: existingIds.length, notFound: missingIds }
+      }
+
+      case 'reorderItems': {
+        const parsed = (todoTools.reorderItems as any).inputSchema.parse(args)
+        const { existingIds, missingIds } = await splitExistingAndMissingIds(parsed.itemIds, listId)
+        if (existingIds.length > 0) {
+          await reorderItemsMutation(listId, existingIds)
+        }
+        return { success: true, notFound: missingIds }
       }
 
       case 'addAndCompleteItems': {

--- a/src/lib/llm/prompts.ts
+++ b/src/lib/llm/prompts.ts
@@ -72,6 +72,7 @@ export function buildSystemPrompt(list: ListContext, items: ItemContext[], infer
       ? [`- You may optionally include metadata if directly stated or strongly implied. Allowed values: ${CORE_METADATA_RULES}. Metadata goes in the metadata field, not in item text.`]
       : []),
     '- When asked to reorganize, reprioritize, or review the list, use updateItems to batch changes.',
+    '- When asked to sort, prioritize, or reorder the list, use reorderItems with item IDs in the desired order.',
     '- If a request is ambiguous or matches multiple items, ask which one.',
     '',
     'Conversation rules:',

--- a/src/lib/llm/prompts.ts
+++ b/src/lib/llm/prompts.ts
@@ -67,12 +67,12 @@ export function buildSystemPrompt(list: ListContext, items: ItemContext[], infer
     '- When they say they already have something, mark it complete or remove it as appropriate.',
     '- When they mention new things to do or buy, add them as individual items.',
     '- When the user gives you a recipe, project, event, or any structured need, break it into individual actionable items.',
-    '- Create a separate item for each distinct thing. Do not combine multiple items into one.',
-    ...(inferMetadata
-      ? [`- You may optionally include metadata if directly stated or strongly implied. Allowed values: ${CORE_METADATA_RULES}. Metadata goes in the metadata field, not in item text.`]
-      : []),
-    '- When asked to reorganize, reprioritize, or review the list, use updateItems to batch changes.',
-    '- When asked to sort, prioritize, or reorder the list, use reorderItems with item IDs in the desired order.',
+     '- Create a separate item for each distinct thing. Do not combine multiple items into one.',
+     ...(inferMetadata
+       ? [`- You may optionally include metadata if directly stated or strongly implied. Allowed values: ${CORE_METADATA_RULES}. Metadata goes in the metadata field, not in item text.`]
+       : []),
+     '- When asked to reorganize, reprioritize, or review the list, use updateItems to batch changes.',
+     '- When asked to sort, prioritize, or reorder the list, use reorderItems with item IDs in the desired order.',
     '- If a request is ambiguous or matches multiple items, ask which one.',
     '',
     'Conversation rules:',

--- a/src/lib/llm/tools.test.ts
+++ b/src/lib/llm/tools.test.ts
@@ -102,6 +102,12 @@ describe('reorderItems schema', () => {
   it('rejects non-array', () => {
     expect(() => (todoTools.reorderItems.inputSchema as any).parse({ itemIds: 'notarray' })).toThrow()
   })
+
+  it('rejects duplicate IDs', () => {
+    expect(() => (todoTools.reorderItems.inputSchema as any).parse({ itemIds: ['id1', 'id1'] })).toThrow(
+      'itemIds must not contain duplicates'
+    )
+  })
 })
 
 describe('addAndCompleteItems schema', () => {

--- a/src/lib/llm/tools.test.ts
+++ b/src/lib/llm/tools.test.ts
@@ -79,6 +79,31 @@ describe('updateItem schema', () => {
   })
 })
 
+describe('reorderItems schema', () => {
+  it('accepts valid input with multiple IDs', () => {
+    const result = (todoTools.reorderItems.inputSchema as any).parse({
+      itemIds: ['id1', 'id2'],
+    })
+    expect(result.itemIds).toHaveLength(2)
+    expect(result.itemIds).toEqual(['id1', 'id2'])
+  })
+
+  it('accepts valid input with single ID', () => {
+    const result = (todoTools.reorderItems.inputSchema as any).parse({
+      itemIds: ['id1'],
+    })
+    expect(result.itemIds).toHaveLength(1)
+  })
+
+  it('rejects empty array', () => {
+    expect(() => (todoTools.reorderItems.inputSchema as any).parse({ itemIds: [] })).toThrow()
+  })
+
+  it('rejects non-array', () => {
+    expect(() => (todoTools.reorderItems.inputSchema as any).parse({ itemIds: 'notarray' })).toThrow()
+  })
+})
+
 describe('addAndCompleteItems schema', () => {
   it('accepts valid input', () => {
     const result = (todoTools.addAndCompleteItems.inputSchema as any).parse({

--- a/src/lib/llm/tools.ts
+++ b/src/lib/llm/tools.ts
@@ -50,7 +50,7 @@ export const todoTools = {
   }),
 
   updateItems: tool({
-    description: `Update metadata for multiple items at once. Use this when the user asks to reprioritize, recategorize, or review the entire list. Use only this core metadata schema: ${CORE_METADATA_RULES}.`,
+    description: `Update metadata for multiple items at once. Use this when the user asks to review the list or change metadata like priority or effort across multiple items. Use only this core metadata schema: ${CORE_METADATA_RULES}.`,
     inputSchema: z.object({
       updates: z.array(z.object({
         itemId: z.string().describe('The ID of the item to update'),
@@ -67,7 +67,7 @@ export const todoTools = {
   }),
 
   reorderItems: tool({
-    description: 'Reorder items in the list. Use when the user asks to sort, prioritize, or rearrange items. Accepts an array of item IDs in the desired order.',
+    description: 'Reorder items in the list. Use when the user asks to sort, reorder, or rearrange the visible order of items. Accepts an array of item IDs in the desired order.',
     inputSchema: z.object({
       itemIds: reorderItemIdsSchema.describe('Array of unique item IDs in the desired order'),
     }),

--- a/src/lib/llm/tools.ts
+++ b/src/lib/llm/tools.ts
@@ -60,6 +60,13 @@ export const todoTools = {
     }),
   }),
 
+  reorderItems: tool({
+    description: 'Reorder items in the list. Use when the user asks to sort, prioritize, or rearrange items. Accepts an array of item IDs in the desired order.',
+    inputSchema: z.object({
+      itemIds: z.array(z.string()).min(1).describe('Array of item IDs in the desired order'),
+    }),
+  }),
+
   addAndCompleteItems: tool({
     description: 'Add items to the list AND immediately mark them as completed. Use this ONLY when the user mentions tasks they have ALREADY done that are not currently on the list (e.g., "I already walked the dog", "Oh I also picked up the dry cleaning").',
     inputSchema: z.object({

--- a/src/lib/llm/tools.ts
+++ b/src/lib/llm/tools.ts
@@ -12,6 +12,12 @@ const itemInputSchema = z.array(z.object({
   metadata: coreMetadataSchema.optional().describe(`Optional inferred metadata using only these keys and values: ${CORE_METADATA_RULES}`),
 }))
 
+const reorderItemIdsSchema = z.array(z.string())
+  .min(1)
+  .refine(itemIds => new Set(itemIds).size === itemIds.length, {
+    message: 'itemIds must not contain duplicates',
+  })
+
 export const todoTools = {
   addItems: tool({
     description: `Add one or more new todo items to the current list. Use this when the user describes tasks, activities, or things they need to do. Infer metadata from context when possible using only this core schema: ${CORE_METADATA_RULES}.`,
@@ -63,7 +69,7 @@ export const todoTools = {
   reorderItems: tool({
     description: 'Reorder items in the list. Use when the user asks to sort, prioritize, or rearrange items. Accepts an array of item IDs in the desired order.',
     inputSchema: z.object({
-      itemIds: z.array(z.string()).min(1).describe('Array of item IDs in the desired order'),
+      itemIds: reorderItemIdsSchema.describe('Array of unique item IDs in the desired order'),
     }),
   }),
 


### PR DESCRIPTION
Closes #4

## Summary
Adds the reorderItems tool to enable AI to reorder list items by their IDs.

## Changes
- New reorderItems tool with ID validation
- Updated system prompt to include the new tool
- Tool validates that all provided IDs exist in the current list

## Notes
Pre-existing prompts.test.ts failure is unrelated to this change.