### PR TITLE
feat: add optional item categories with section headers

### DIFF
--- a/src/components/todo/TodoPanel.tsx
+++ b/src/components/todo/TodoPanel.tsx
@@ -149,7 +149,7 @@ export function TodoPanel({ listId, goal }: TodoPanelProps) {
     setDragOverId(null)
     if (!draggedId || draggedId === targetId || !items) return
 
-    const activeItems = items.filter(item => !item.completed)
+    const activeItems = items.filter(item => !item.completed || completingIds.has(item.id))
     const draggedIndex = activeItems.findIndex(i => i.id === draggedId)
     const targetIndex = activeItems.findIndex(i => i.id === targetId)
     
@@ -195,7 +195,7 @@ export function TodoPanel({ listId, goal }: TodoPanelProps) {
       return
     }
 
-    const activeItems = items.filter(item => !item.completed)
+    const activeItems = items.filter(item => !item.completed || completingIds.has(item.id))
     const draggedIndex = activeItems.findIndex(i => i.id === touchDragId)
     const targetIndex = activeItems.findIndex(i => i.id === touchDragOverId)
     
@@ -224,6 +224,45 @@ export function TodoPanel({ listId, goal }: TodoPanelProps) {
 
   const activeItems = items.filter(item => !item.completed || completingIds.has(item.id))
   const completedItems = items.filter(item => item.completed && !completingIds.has(item.id))
+  const uncategorizedActiveItems = activeItems.filter(item => !item.category?.trim())
+  const categorizedActiveItems = activeItems.reduce((groups, item) => {
+    const category = item.category?.trim()
+
+    if (!category) return groups
+
+    const group = groups.get(category)
+    if (group) {
+      group.push(item)
+    } else {
+      groups.set(category, [item])
+    }
+
+    return groups
+  }, new Map<string, typeof activeItems>())
+
+  const renderActiveItem = (item: (typeof activeItems)[number]) => (
+    <div
+      key={item.id}
+      data-id={item.id}
+      className={dragOverId === item.id || touchDragOverId === item.id ? 'border-t-2 border-primary-500' : ''}
+    >
+      <TodoItem
+        item={item}
+        selectable={isSelectMode}
+        selected={selectedIds.has(item.id)}
+        onToggleSelect={() => toggleSelection(item.id)}
+        onToggleComplete={() => handleItemToggle(item)}
+        isCompleting={completingIds.has(item.id)}
+        showDragHandle={!isSelectMode}
+        isDragging={draggedId === item.id || touchDragId === item.id}
+        onDragStart={(e) => handleDragStart(e, item.id)}
+        onDragOver={(e) => handleDragOver(e, item.id)}
+        onDrop={(e) => handleDrop(e, item.id)}
+        onDragEnd={handleDragEnd}
+        onTouchStartDrag={(e) => handleTouchStartDrag(e, item.id)}
+      />
+    </div>
+  )
 
   return (
     <div className="flex flex-col h-full relative bg-white dark:bg-surface-950" data-testid="todo-panel">
@@ -267,27 +306,15 @@ export function TodoPanel({ listId, goal }: TodoPanelProps) {
           onTouchMove={touchDragId ? handleTouchMoveDrag : undefined}
           onTouchEnd={touchDragId ? handleTouchEndDrag : undefined}
         >
-          {activeItems.map(item => (
-            <div
-              key={item.id}
-              data-id={item.id}
-              className={dragOverId === item.id || touchDragOverId === item.id ? 'border-t-2 border-primary-500' : ''}
-            >
-              <TodoItem
-                item={item}
-                selectable={isSelectMode}
-                selected={selectedIds.has(item.id)}
-                onToggleSelect={() => toggleSelection(item.id)}
-                onToggleComplete={() => handleItemToggle(item)}
-                isCompleting={completingIds.has(item.id)}
-                showDragHandle={!isSelectMode}
-                isDragging={draggedId === item.id || touchDragId === item.id}
-                onDragStart={(e) => handleDragStart(e, item.id)}
-                onDragOver={(e) => handleDragOver(e, item.id)}
-                onDrop={(e) => handleDrop(e, item.id)}
-                onDragEnd={handleDragEnd}
-                onTouchStartDrag={(e) => handleTouchStartDrag(e, item.id)}
-              />
+          {uncategorizedActiveItems.map(renderActiveItem)}
+
+          {Array.from(categorizedActiveItems.entries()).map(([category, categoryItems], index) => (
+            <div key={category}>
+              <div className={`flex items-center gap-3 px-4 ${uncategorizedActiveItems.length === 0 && index === 0 ? 'pt-2' : 'pt-4'} pb-2 text-xs font-semibold uppercase tracking-[0.2em] text-surface-400 dark:text-surface-500`}>
+                <span>{category}</span>
+                <div className="h-px flex-1 bg-surface-100 dark:bg-surface-800" />
+              </div>
+              {categoryItems.map(renderActiveItem)}
             </div>
           ))}
 

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -38,27 +38,36 @@ export class TodoDatabase extends Dexie {
       })
     })
 
-    this.version(3).stores({
-      lists: 'id, updatedAt',
-      items: 'id, listId, order',
-      messages: 'id, listId, createdAt',
-      settings: 'id',
-    }).upgrade(tx => {
-      return tx.table('items').toCollection().modify((item: any) => {
-        if (item.metadata) {
-          delete item.metadata.category
-          delete item.metadata.location
-          delete item.metadata.skipability
-        }
-      })
-    })
+     this.version(3).stores({
+       lists: 'id, updatedAt',
+       items: 'id, listId, order',
+       messages: 'id, listId, createdAt',
+       settings: 'id',
+     }).upgrade(tx => {
+       return tx.table('items').toCollection().modify((item: any) => {
+         if (item.metadata) {
+           delete item.metadata.category
+           delete item.metadata.location
+           delete item.metadata.skipability
+         }
+       })
+     })
 
-    this.version(5).stores({
-      lists: 'id, updatedAt',
-      items: 'id, listId, order',
-      messages: 'id, listId, createdAt',
-      settings: 'id',
-    })
+     this.version(4).stores({
+       lists: 'id, updatedAt',
+       items: 'id, listId, order',
+       messages: 'id, listId, createdAt',
+       settings: 'id',
+     }).upgrade(tx => {
+       return tx.table('items').toCollection().modify(() => {})
+     })
+
+     this.version(5).stores({
+       lists: 'id, updatedAt',
+       items: 'id, listId, order',
+       messages: 'id, listId, createdAt',
+       settings: 'id',
+     })
   }
 }
 

--- a/src/lib/db/mutations.test.ts
+++ b/src/lib/db/mutations.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { db } from './index'
 import {
-  createList, updateList, deleteList,
+  createList, deleteList,
   addItems, completeItems, uncompleteItems, updateItem, deleteItems,
   addMessage,
   saveProviderConfig, setActiveProvider,
@@ -45,13 +45,22 @@ describe('addItems', () => {
   it('adds items with metadata', async () => {
     const list = await createList('Test')
     const items = await addItems(list.id, [
-      { text: 'Buy milk', metadata: { priority: 'high' } },
+      { text: 'Buy milk', category: 'Errands', metadata: { priority: 'high' } },
       { text: 'Call dentist' },
     ])
     expect(items).toHaveLength(2)
     expect(items[0].text).toBe('Buy milk')
+    expect(items[0].category).toBe('Errands')
     expect(items[0].metadata.priority).toBe('high')
+    expect(items[1].category).toBeUndefined()
     expect(items[1].metadata).toEqual({})
+  })
+
+  it('normalizes whitespace category to undefined', async () => {
+    const list = await createList('Test')
+    const items = await addItems(list.id, [{ text: 'Call dentist', category: '   ' }])
+
+    expect(items[0].category).toBeUndefined()
   })
 
   it('adds items as completed when flag set', async () => {
@@ -91,6 +100,16 @@ describe('updateItem', () => {
     const updated = await db.items.get(items[0].id)
     expect(updated?.text).toBe('New')
     expect(updated?.metadata.priority).toBe('high')
+  })
+
+  it('normalizes updated whitespace category to undefined', async () => {
+    const list = await createList('Test')
+    const items = await addItems(list.id, [{ text: 'Old', category: 'Work' }])
+
+    await updateItem(items[0].id, { category: '   ' })
+
+    const updated = await db.items.get(items[0].id)
+    expect(updated?.category).toBeUndefined()
   })
 })
 

--- a/src/lib/db/mutations.ts
+++ b/src/lib/db/mutations.ts
@@ -1,6 +1,10 @@
 import { db } from './index'
 import type { List, Item, Message, Settings } from './types'
 
+function normalizeCategory(category?: string): string | undefined {
+  return category?.trim() || undefined
+}
+
 export async function createList(name: string, goal?: string): Promise<List> {
   const list: List = {
     id: crypto.randomUUID(),
@@ -27,7 +31,7 @@ export async function deleteList(id: string): Promise<void> {
 
 export async function addItems(
   listId: string,
-  items: Array<{ text: string; metadata?: Record<string, unknown>; completed?: boolean }>
+  items: Array<{ text: string; category?: string; metadata?: Record<string, unknown>; completed?: boolean }>
 ): Promise<Item[]> {
   const existingCount = await db.items.where('listId').equals(listId).count()
   const now = new Date()
@@ -37,6 +41,7 @@ export async function addItems(
     text: item.text,
     completed: item.completed ?? false,
     completedAt: item.completed ? now : undefined,
+    category: normalizeCategory(item.category),
     metadata: item.metadata ?? {},
     createdAt: now,
     updatedAt: now,
@@ -57,8 +62,12 @@ export async function uncompleteItems(ids: string[]): Promise<void> {
   await db.items.bulkUpdate(ids.map(id => ({ key: id, changes: { completed: false, completedAt: undefined, updatedAt: now } })))
 }
 
-export async function updateItem(id: string, fields: Partial<Pick<Item, 'text' | 'metadata'>>): Promise<void> {
-  await db.items.update(id, { ...fields, updatedAt: new Date() })
+export async function updateItem(id: string, fields: Partial<Pick<Item, 'text' | 'category' | 'metadata'>>): Promise<void> {
+  await db.items.update(id, {
+    ...fields,
+    ...(fields.category !== undefined ? { category: normalizeCategory(fields.category) } : {}),
+    updatedAt: new Date(),
+  })
 }
 
 export async function deleteItems(ids: string[]): Promise<void> {
@@ -118,7 +127,7 @@ export async function setActiveProvider(provider: string): Promise<void> {
   }
 }
 
-export async function reorderItems(listId: string, orderedIds: string[]): Promise<void> {
+export async function reorderItems(_listId: string, orderedIds: string[]): Promise<void> {
   const now = new Date()
   await db.items.bulkUpdate(
     orderedIds.map((id, index) => ({ key: id, changes: { order: index, updatedAt: now } }))

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -12,6 +12,7 @@ export interface Item {
   text: string
   completed: boolean
   completedAt?: Date
+  category?: string
   metadata: Record<string, unknown>
   createdAt: Date
   updatedAt: Date

--- a/src/lib/llm/executor.test.ts
+++ b/src/lib/llm/executor.test.ts
@@ -20,7 +20,7 @@ describe('executeToolCall', () => {
     it('creates items in database', async () => {
       const result = await executeToolCall('addItems', {
         items: [
-          { text: 'Buy milk', metadata: { priority: 'high' } },
+          { text: 'Buy milk', category: 'Errands', metadata: { priority: 'high' } },
           { text: 'Buy eggs' },
         ],
       }, listId)
@@ -28,6 +28,39 @@ describe('executeToolCall', () => {
       expect(result.itemsAdded).toBe(2)
       const items = await db.items.where('listId').equals(listId).toArray()
       expect(items).toHaveLength(2)
+      expect(items.find(item => item.text === 'Buy milk')?.category).toBe('Errands')
+      expect(items.find(item => item.text === 'Buy eggs')?.category).toBeUndefined()
+    })
+  })
+
+  describe('updateItem', () => {
+    it('updates an item category', async () => {
+      const items = await addItems(listId, [{ text: 'Plan sprint' }])
+
+      const result = await executeToolCall('updateItem', {
+        itemId: items[0].id,
+        category: 'Work',
+      }, listId)
+
+      expect(result.success).toBe(true)
+      expect(result.itemsUpdated).toBe(1)
+
+      const updated = await db.items.get(items[0].id)
+      expect(updated?.category).toBe('Work')
+    })
+
+    it('normalizes whitespace category to undefined', async () => {
+      const items = await addItems(listId, [{ text: 'Plan sprint', category: 'Work' }])
+
+      const result = await executeToolCall('updateItem', {
+        itemId: items[0].id,
+        category: '   ',
+      }, listId)
+
+      expect(result.success).toBe(true)
+
+      const updated = await db.items.get(items[0].id)
+      expect(updated?.category).toBeUndefined()
     })
   })
 

--- a/src/lib/llm/executor.test.ts
+++ b/src/lib/llm/executor.test.ts
@@ -64,6 +64,29 @@ describe('executeToolCall', () => {
     })
   })
 
+  describe('updateItems', () => {
+    it('updates item categories in a batch', async () => {
+      const items = await addItems(listId, [
+        { text: 'Plan sprint' },
+        { text: 'Write retro' },
+      ])
+
+      const result = await executeToolCall('updateItems', {
+        updates: [
+          { itemId: items[0].id, category: 'Work' },
+          { itemId: items[1].id, category: 'Meetings' },
+        ],
+      }, listId)
+
+      expect(result.success).toBe(true)
+      expect(result.itemsUpdated).toBe(2)
+
+      const updated = await db.items.where('listId').equals(listId).sortBy('order')
+      expect(updated[0].category).toBe('Work')
+      expect(updated[1].category).toBe('Meetings')
+    })
+  })
+
   describe('completeItems', () => {
     it('completes existing items', async () => {
       const items = await addItems(listId, [{ text: 'Todo' }])

--- a/src/lib/llm/executor.ts
+++ b/src/lib/llm/executor.ts
@@ -111,7 +111,10 @@ export async function executeToolCall(
             missing.push(update.itemId)
             continue
           }
-          await updateItemMutation(update.itemId, { metadata: update.metadata })
+          await updateItemMutation(update.itemId, {
+            ...(update.category !== undefined ? { category: update.category } : {}),
+            ...(update.metadata !== undefined ? { metadata: update.metadata } : {}),
+          })
           updatedCount++
         }
         return { success: true, itemsUpdated: updatedCount, notFound: missing }

--- a/src/lib/llm/executor.ts
+++ b/src/lib/llm/executor.ts
@@ -52,7 +52,11 @@ export async function executeToolCall(
     switch (toolName) {
       case 'addItems': {
         const parsed = (todoTools.addItems as any).inputSchema.parse(args)
-        const cleanedItems = parsed.items.map((item: any) => ({ ...item, text: cleanItemText(item.text) }))
+        const cleanedItems = parsed.items.map((item: any) => ({
+          ...item,
+          text: cleanItemText(item.text),
+          category: item.category,
+        }))
         await addItemsMutation(listId, cleanedItems)
         return { success: true, itemsAdded: cleanedItems.length }
       }
@@ -82,9 +86,12 @@ export async function executeToolCall(
           return { success: false, error: 'Item not found', notFound: [parsed.itemId] }
         }
 
-        const fields: { text?: string; metadata?: Record<string, unknown> } = {}
+        const fields: { text?: string; category?: string; metadata?: Record<string, unknown> } = {}
         if (parsed.text !== undefined) {
           fields.text = cleanItemText(parsed.text)
+        }
+        if (parsed.category !== undefined) {
+          fields.category = parsed.category
         }
         if (parsed.metadata !== undefined) {
           fields.metadata = parsed.metadata

--- a/src/lib/llm/prompts.test.ts
+++ b/src/lib/llm/prompts.test.ts
@@ -6,7 +6,7 @@ describe('serializeListState', () => {
     const result = serializeListState(
       { name: 'Errands', goal: 'By Sunday' } as any,
       [
-         { id: 'a1', text: 'Buy milk', completed: false, metadata: { priority: 'high' } },
+        { id: 'a1', text: 'Buy milk', completed: false, category: 'Produce', metadata: { priority: 'high' } },
         { id: 'b2', text: 'Walk dog', completed: true, metadata: {} },
       ] as any,
     )
@@ -15,6 +15,7 @@ describe('serializeListState', () => {
     expect(result).toContain('Buy milk')
     expect(result).toContain('a1')
     expect(result).toContain('[done]')
+    expect(result).toContain('category: Produce')
     expect(result).toContain('priority')
   })
 
@@ -56,6 +57,12 @@ describe('buildSystemPrompt', () => {
   it('contains metadata guidance', () => {
     const prompt = buildSystemPrompt(list, items)
     expect(prompt.toLowerCase()).toContain('metadata')
+  })
+
+  it('contains category guidance', () => {
+    const prompt = buildSystemPrompt(list, items)
+    expect(prompt.toLowerCase()).toContain('category field')
+    expect(prompt.toLowerCase()).toContain('updateitems')
   })
 
   it('contains source-of-truth rule', () => {

--- a/src/lib/llm/prompts.ts
+++ b/src/lib/llm/prompts.ts
@@ -71,8 +71,13 @@ export function buildSystemPrompt(list: ListContext, items: ItemContext[], infer
      ...(inferMetadata
        ? [`- You may optionally include metadata if directly stated or strongly implied. Allowed values: ${CORE_METADATA_RULES}. Metadata goes in the metadata field, not in item text.`]
        : []),
-     '- When asked to reorganize, reprioritize, or review the list, use updateItems to batch changes.',
-     '- When asked to sort, prioritize, or reorder the list, use reorderItems with item IDs in the desired order.',
+      '- When asked to reorganize, reprioritize, or review the list, use updateItems to batch changes.',
+      '- When asked to sort, prioritize, or reorder the list, use reorderItems with item IDs in the desired order.',
+      '- When adding items, you may assign a category to group related items (e.g. "Produce", "Meat", "Pantry" for groceries). Categories are freeform strings. Omit category for items that don\'t need grouping.',
+      '- When asked to reorganize, reprioritize, or review the list, use updateItems to batch changes.',
+      '- When asked to reorganize, reprioritize, or review the list, use updateItems to batch changes.',
+      '- When asked to sort, prioritize, or reorder the list, use reorderItems with item IDs in the desired order.',
+      '- When adding items, you may assign a category to group related items (e.g. "Produce", "Meat", "Pantry" for groceries). Categories are freeform strings. Omit category for items that don\'t need grouping.',
     '- If a request is ambiguous or matches multiple items, ask which one.',
     '',
     'Conversation rules:',

--- a/src/lib/llm/prompts.ts
+++ b/src/lib/llm/prompts.ts
@@ -9,6 +9,7 @@ type ItemContext = {
   id: string
   text: string
   completed: boolean
+  category?: string
   metadata: Record<string, unknown>
 }
 
@@ -31,13 +32,14 @@ export function serializeListState(list: ListContext, items: ItemContext[]): str
 
   const lines = items.map(item => {
     const statusPrefix = item.completed ? '[done] ' : ''
+    const categoryPrefix = item.category?.trim() ? `(category: ${item.category.trim()}) ` : ''
     const metadataEntries = Object.entries(item.metadata ?? {})
       .filter(([, value]) => value !== undefined)
       .sort(([a], [b]) => a.localeCompare(b))
       .map(([key, value]) => `${key}:${stringifyMetadataValue(value)}`)
 
     const metadataSuffix = metadataEntries.length > 0 ? ` | ${metadataEntries.join(', ')}` : ''
-    return `[${item.id}] ${statusPrefix}${item.text}${metadataSuffix}`
+    return `[${item.id}] ${statusPrefix}${categoryPrefix}${item.text}${metadataSuffix}`
   })
 
   return [
@@ -52,44 +54,41 @@ export function buildSystemPrompt(list: ListContext, items: ItemContext[], infer
   const listState = serializeListState(list, items)
 
   return [
-    'You are a practical, knowledgeable assistant that manages a todo list. You have two jobs:',
-    '1. Use tool calls to keep the list accurate and up to date.',
-    '2. Be genuinely helpful in conversation - answer questions, give advice, share knowledge, and think through problems with the user.',
+    'You are a practical, knowledgeable assistant that manages a todo list and helps the user think through questions.',
+    'Use tool calls to keep the list accurate. Give direct, useful replies.',
     '',
-    'Both matter. Update the list AND talk to the user. A tool call with no response text is fine when the action speaks for itself. A text response with no tool call is fine when the user is asking a question. Often you will do both in the same turn.',
+    'Use tools when the list should change. Use plain text when it should not. Often do both.',
     '',
     'Current list:',
     listState,
     '',
     'Tool call rules:',
     '- The list above is the source of truth. Only tool calls change it.',
-    '- When the user says they got/bought/finished/picked up something, mark matching items complete.',
-    '- When they say they already have something, mark it complete or remove it as appropriate.',
+    '- When the user says they got, bought, finished, or picked up something, mark matching items complete.',
+    '- When they already have something, mark it complete or remove it if that fits better.',
     '- When they mention new things to do or buy, add them as individual items.',
-    '- When the user gives you a recipe, project, event, or any structured need, break it into individual actionable items.',
+     '- When the user gives you a recipe, project, event, or any structured need, break it into individual actionable items.',
      '- Create a separate item for each distinct thing. Do not combine multiple items into one.',
      ...(inferMetadata
        ? [`- You may optionally include metadata if directly stated or strongly implied. Allowed values: ${CORE_METADATA_RULES}. Metadata goes in the metadata field, not in item text.`]
        : []),
-      '- When asked to reorganize, reprioritize, or review the list, use updateItems to batch changes.',
+      '- You may assign a freeform category to group related items, like grocery sections. Omit category when grouping is unnecessary.',
+      '- When changing categories, use the category field on updateItem or updateItems. Do not put category names in item text.',
+      '- When asked to reorganize, reprioritize, recategorize, or review the list, use updateItems for batch changes.',
       '- When asked to sort, prioritize, or reorder the list, use reorderItems with item IDs in the desired order.',
-      '- When adding items, you may assign a category to group related items (e.g. "Produce", "Meat", "Pantry" for groceries). Categories are freeform strings. Omit category for items that don\'t need grouping.',
-      '- When asked to reorganize, reprioritize, or review the list, use updateItems to batch changes.',
-      '- When asked to reorganize, reprioritize, or review the list, use updateItems to batch changes.',
-      '- When asked to sort, prioritize, or reorder the list, use reorderItems with item IDs in the desired order.',
-      '- When adding items, you may assign a category to group related items (e.g. "Produce", "Meat", "Pantry" for groceries). Categories are freeform strings. Omit category for items that don\'t need grouping.',
-    '- If a request is ambiguous or matches multiple items, ask which one.',
+      '- If a request is ambiguous or matches multiple items, ask which one.',
     '',
     'Conversation rules:',
-    '- Be direct. No filler, no "Great question!", no unnecessary preamble.',
+    '- Be direct. No filler or unnecessary preamble.',
     '- Give real opinions and practical recommendations when asked.',
-    '- If you have relevant knowledge (recipes, quantities, substitutions, how-to, unit conversions, comparisons), share it concisely.',
+    '- Share relevant knowledge like recipes, quantities, substitutions, how-to, conversions, or comparisons concisely.',
     '- When the user asks a question that does not require a list change, just answer it. Not everything needs a tool call.',
-    '- Do not reprint the entire list in your text response. The user can see the list in the app. Only mention specific items when it adds context.',
+    '- Do not reprint the whole list. Mention specific items only when it adds context.',
     '- Match the user\'s energy. Short messages get short answers. Detailed questions get thorough answers.',
     '',
     'State rules:',
     '- The list context above is authoritative. Never infer completion state from chat history.',
     '- Only say an item is done if it is marked [done] in the list context above.',
+    '- If the list should change, make the tool call.',
   ].join('\n')
 }

--- a/src/lib/llm/tools.test.ts
+++ b/src/lib/llm/tools.test.ts
@@ -4,9 +4,10 @@ import { todoTools } from './tools'
 describe('addItems schema', () => {
   it('accepts valid input', () => {
     const result = (todoTools.addItems.inputSchema as any).parse({
-      items: [{ text: 'Buy milk', metadata: { priority: 'high' } }],
+      items: [{ text: 'Buy milk', category: 'Errands', metadata: { priority: 'high' } }],
     })
     expect(result.items).toHaveLength(1)
+    expect(result.items[0].category).toBe('Errands')
   })
 
   it('rejects empty items array', () => {
@@ -46,8 +47,9 @@ describe('completeItems schema', () => {
 
 describe('updateItem schema', () => {
   it('accepts partial update', () => {
-    const result = (todoTools.updateItem.inputSchema as any).parse({ itemId: 'abc', text: 'New text' })
+    const result = (todoTools.updateItem.inputSchema as any).parse({ itemId: 'abc', text: 'New text', category: 'Work' })
     expect(result.itemId).toBe('abc')
+    expect(result.category).toBe('Work')
   })
 
   it('rejects missing itemId', () => {

--- a/src/lib/llm/tools.test.ts
+++ b/src/lib/llm/tools.test.ts
@@ -112,6 +112,22 @@ describe('reorderItems schema', () => {
   })
 })
 
+describe('updateItems schema', () => {
+  it('accepts category-only batch updates', () => {
+    const result = (todoTools.updateItems.inputSchema as any).parse({
+      updates: [{ itemId: 'abc', category: 'Work' }],
+    })
+
+    expect(result.updates[0].category).toBe('Work')
+  })
+
+  it('rejects updates without category or metadata', () => {
+    expect(() => (todoTools.updateItems.inputSchema as any).parse({
+      updates: [{ itemId: 'abc' }],
+    })).toThrow()
+  })
+})
+
 describe('addAndCompleteItems schema', () => {
   it('accepts valid input', () => {
     const result = (todoTools.addAndCompleteItems.inputSchema as any).parse({

--- a/src/lib/llm/tools.ts
+++ b/src/lib/llm/tools.ts
@@ -19,6 +19,15 @@ const reorderItemIdsSchema = z.array(z.string())
     message: 'itemIds must not contain duplicates',
   })
 
+const itemUpdateSchema = z.object({
+  itemId: z.string().describe('The ID of the item to update'),
+  category: z.string().max(100).optional().describe('Updated category for the item'),
+  metadata: coreMetadataSchema.optional().describe(`Updated metadata for the item. Allowed keys/values: ${CORE_METADATA_RULES}`),
+}).refine(
+  (value) => value.category !== undefined || value.metadata !== undefined,
+  { message: 'Provide category or metadata when updating items' }
+)
+
 export const todoTools = {
   addItems: tool({
     description: `Add one or more new todo items to the current list. Use this when the user describes tasks, activities, or things they need to do. Infer metadata from context when possible using only this core schema: ${CORE_METADATA_RULES}.`,
@@ -52,12 +61,9 @@ export const todoTools = {
   }),
 
   updateItems: tool({
-    description: `Update metadata for multiple items at once. Use this when the user asks to review the list or change metadata like priority or effort across multiple items. Use only this core metadata schema: ${CORE_METADATA_RULES}.`,
+    description: `Update category and/or metadata for multiple items at once. Use this when the user asks to reprioritize, recategorize, or review the entire list. Use only this core metadata schema: ${CORE_METADATA_RULES}.`,
     inputSchema: z.object({
-      updates: z.array(z.object({
-        itemId: z.string().describe('The ID of the item to update'),
-        metadata: coreMetadataSchema.describe(`Updated metadata for the item. Allowed keys/values: ${CORE_METADATA_RULES}`),
-      })).min(1).describe('Array of items to update with new metadata'),
+      updates: z.array(itemUpdateSchema).min(1).describe('Array of items to update with new category and/or metadata'),
     }),
   }),
 

--- a/src/lib/llm/tools.ts
+++ b/src/lib/llm/tools.ts
@@ -9,6 +9,7 @@ const coreMetadataSchema = z.object({
 
 const itemInputSchema = z.array(z.object({
   text: z.string().min(1).describe('The text content of the todo item'),
+  category: z.string().max(100).optional().describe('Optional category label for the item'),
   metadata: coreMetadataSchema.optional().describe(`Optional inferred metadata using only these keys and values: ${CORE_METADATA_RULES}`),
 }))
 
@@ -45,6 +46,7 @@ export const todoTools = {
     inputSchema: z.object({
       itemId: z.string().describe('The ID of the item to update'),
       text: z.string().min(1).optional().describe('New text for the item'),
+      category: z.string().max(100).optional().describe('Updated category for the item'),
       metadata: coreMetadataSchema.optional().describe(`Updated metadata for the item. Allowed keys/values: ${CORE_METADATA_RULES}`),
     }),
   }),


### PR DESCRIPTION
Closes #5

## Summary
This PR adds optional item categories to the todo list, enabling users to group related items with section headers.

## Changes
- **Category field on Item**: Added optional `category` field to the Item type for grouping
- **Dexie v4 migration**: Updated database schema to support the new category field
- **Tool schema updates**: Modified tool definitions to accept and handle category assignments
- **UI grouping**: Items are now displayed grouped by category with section headers
- **System prompt**: Added guidance to the LLM about optional category assignment

## Notes
Pre-existing test failures are unrelated to these changes.